### PR TITLE
enhancement: Added the ability to configure a list of domains and only send mail to addresses in those domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ make docker
 make docker-run
 ```
 
+### Configuration
+A number of environment variables are available to configure the service at runtime:
+| Env var name | Functionality | Default |
+|--------------|---------------|---------|
+| SERVICE_PORT                      | The local port the application will bind to | 80 |
+| SENDGRID_API_KEY                  | The API Key for sendgrid | |
+| SLACK_API_KEY                     | The API Token for Slack | |
+| GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS | The number of seconds the application will continue servicing in-flight requests before the application stops after it receives an interrupt signal | 10 |
+| STRUCTURED_LOGGING                | If enabled, logs will be in JSON format, and only above INFO level | false |
+| ALLOW_EMAIL_TO_DOMAINS            | A comma separated list of domains. Only addresses in this list can have email sent to them. If empty, disable this "sandboxing" functionality. | |
+
+
 ### Releasing a new version on GitHub and Brew
 
 We are using a tool called `goreleaser` which you can get from brew if you're on MacOS:

--- a/charts/zero-notifcation-service/Chart.yaml
+++ b/charts/zero-notifcation-service/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.0.5
+appVersion: 0.0.9

--- a/charts/zero-notifcation-service/templates/configmap.yaml
+++ b/charts/zero-notifcation-service/templates/configmap.yaml
@@ -6,3 +6,4 @@ data:
     SERVICE_PORT: "{{ .Values.service.port }}"
     GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS: "{{ .Values.application.gracefulShutdownTimeout }}"
     STRUCTURED_LOGGING: "{{ .Values.application.structuredLogging }}"
+    ALLOW_EMAIL_TO_DOMAINS: "{{ .Values.application.allowEmailToDomains }}"

--- a/charts/zero-notifcation-service/values.yaml
+++ b/charts/zero-notifcation-service/values.yaml
@@ -76,9 +76,11 @@ affinity: {}
 
 
 # Application Config
+# See project readme for more information about config options
 
 application:
   sendgridApiKey:
   slackApiKey:
   gracefulShutdownTimeout: 10
   structuredLogging: true
+  allowEmailToDomains:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	SlackAPIKey             string
 	GracefulShutdownTimeout time.Duration
 	StructuredLogging       bool
+	AllowEmailToDomains     []string
 }
 
 var config *Config
@@ -24,6 +25,7 @@ const (
 	SlackAPIKey
 	GracefulShutdownTimeout
 	StructuredLogging
+	AllowEmailToDomains
 )
 
 // GetConfig returns a pointer to the singleton Config object
@@ -50,12 +52,16 @@ func loadConfig() *Config {
 	viper.SetDefault(StructuredLogging, "false")
 	viper.BindEnv(StructuredLogging, "STRUCTURED_LOGGING")
 
+	viper.SetDefault(AllowEmailToDomains, []string{})
+	viper.BindEnv(AllowEmailToDomains, "ALLOW_EMAIL_TO_DOMAINS")
+
 	config := Config{
 		Port:                    viper.GetInt(Port),
 		SendgridAPIKey:          viper.GetString(SendgridAPIKey),
 		SlackAPIKey:             viper.GetString(SlackAPIKey),
 		GracefulShutdownTimeout: viper.GetDuration(GracefulShutdownTimeout),
 		StructuredLogging:       viper.GetBool(StructuredLogging),
+		AllowEmailToDomains:     viper.GetStringSlice(AllowEmailToDomains),
 	}
 
 	return &config

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -1,6 +1,8 @@
 package mail
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/commitdev/zero-notification-service/internal/server"
@@ -80,4 +82,26 @@ func convertAddresses(addresses []server.EmailRecipient) []*sendgridMail.Email {
 		returnAddresses[i] = sendgridMail.NewEmail(address.Name, address.Address)
 	}
 	return returnAddresses
+}
+
+// RemoveInvalidRecipients accepts a list of recipients and removes the ones with domains not in the allowed list
+func RemoveInvalidRecipients(recipients []server.EmailRecipient, allowedDomains []string) []server.EmailRecipient {
+	valid := []server.EmailRecipient{}
+	for _, recipient := range recipients {
+
+		if addressInAllowedDomain(recipient.Address, allowedDomains) {
+			valid = append(valid, recipient)
+		}
+	}
+	return valid
+}
+
+// addressInAllowedDomain checks if a single email address is in a list of domains
+func addressInAllowedDomain(address string, domains []string) bool {
+	for _, domain := range domains {
+		if strings.HasSuffix(address, fmt.Sprintf("@%s", domain)) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
A comma separated list of domains can now be specified as an env var, and email sending (including to, cc, bcc) will be restricted to only addresses in those domains.
﻿
