### PR TITLE
feat: add headers support to sendgrid mail

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Generate code
       run: |
-        docker run --rm -v ${GITHUB_WORKSPACE}:/local openapitools/openapi-generator-cli generate -i /local/api/notification-service.yaml -g go-server -o /local/ -p sourceFolder=internal/server -p packageName=server --git-user-id=commitdev --git-repo-id=zero-notification-service
+        docker run --rm -v ${GITHUB_WORKSPACE}:/local openapitools/openapi-generator:cli-5.3.x generate -i /local/api/notification-service.yaml -g go-server -o /local/ -p sourceFolder=internal/server -p packageName=server --git-user-id=commitdev --git-repo-id=zero-notification-service
         sudo chmod -R a+rw ${GITHUB_WORKSPACE}
         go get golang.org/x/tools/cmd/goimports
         goimports -w ${GITHUB_WORKSPACE}/internal/server/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .envrc
 zero-notification-service
 .history/

--- a/api/notification-service.yaml
+++ b/api/notification-service.yaml
@@ -262,6 +262,8 @@ components:
           $ref: '#/components/schemas/EmailSender'
         message:
           $ref: '#/components/schemas/MailMessage'
+        headers:
+          $ref: '#/components/schemas/MailHeaders'
 
     SendBulkMailRequest:
       type: object
@@ -285,6 +287,8 @@ components:
           $ref: '#/components/schemas/EmailSender'
         message:
           $ref: '#/components/schemas/MailMessage'
+        headers:
+          $ref: '#/components/schemas/MailHeaders'
 
     MailMessage:
       type: object
@@ -304,6 +308,11 @@ components:
           type: integer
           description: Schedule these mesages to go out at the time specified by this UNIX timestamp
           format: int64
+
+    MailHeaders:
+      type: object
+      additionalProperties:
+        type: string
 
     SendSMSRequest:
       type: object

--- a/internal/service/api_email_service.go
+++ b/internal/service/api_email_service.go
@@ -43,7 +43,7 @@ func (s *EmailApiService) SendEmail(ctx context.Context, sendMailRequest server.
 
 	client := sendgrid.NewSendClient(s.config.SendgridAPIKey)
 
-	response, err := mail.SendIndividualMail(sendMailRequest.ToAddresses, sendMailRequest.FromAddress, sendMailRequest.CcAddresses, sendMailRequest.BccAddresses,  sendMailRequest.Headers, sendMailRequest.Message, client)
+	response, err := mail.SendIndividualMail(sendMailRequest.ToAddresses, sendMailRequest.FromAddress, sendMailRequest.CcAddresses, sendMailRequest.BccAddresses, sendMailRequest.Headers, sendMailRequest.Message, client)
 
 	if err != nil {
 		zap.S().Errorf("Error sending mail: %v", response)

--- a/internal/service/api_email_service.go
+++ b/internal/service/api_email_service.go
@@ -42,7 +42,8 @@ func (s *EmailApiService) SendEmail(ctx context.Context, sendMailRequest server.
 	}
 
 	client := sendgrid.NewSendClient(s.config.SendgridAPIKey)
-	response, err := mail.SendIndividualMail(sendMailRequest.ToAddresses, sendMailRequest.FromAddress, sendMailRequest.CcAddresses, sendMailRequest.BccAddresses, sendMailRequest.Message, client)
+
+	response, err := mail.SendIndividualMail(sendMailRequest.ToAddresses, sendMailRequest.FromAddress, sendMailRequest.CcAddresses, sendMailRequest.BccAddresses,  sendMailRequest.Headers, sendMailRequest.Message, client)
 
 	if err != nil {
 		zap.S().Errorf("Error sending mail: %v", response)
@@ -79,7 +80,7 @@ func (s *EmailApiService) SendBulk(ctx context.Context, sendBulkMailRequest serv
 
 	responseChannel := make(chan mail.BulkSendAttempt)
 
-	mail.SendBulkMail(sendBulkMailRequest.ToAddresses, sendBulkMailRequest.FromAddress, sendBulkMailRequest.CcAddresses, sendBulkMailRequest.BccAddresses, sendBulkMailRequest.Message, client, responseChannel)
+	mail.SendBulkMail(sendBulkMailRequest.ToAddresses, sendBulkMailRequest.FromAddress, sendBulkMailRequest.CcAddresses, sendBulkMailRequest.BccAddresses, sendBulkMailRequest.Headers, sendBulkMailRequest.Message, client, responseChannel)
 
 	var successful []server.SendBulkMailResponseSuccessful
 	var failed []server.SendBulkMailResponseFailed


### PR DESCRIPTION
ability to specify headers, so can thread messages using `in-reply-to` and any other headers sendgrid support for SMTP headers