### PR TITLE
fix: npm to publish node client instead of browser

### DIFF
--- a/.github/workflows/publish-clients.yml
+++ b/.github/workflows/publish-clients.yml
@@ -21,6 +21,7 @@ jobs:
           -o /local/client \
           -p npmName="@commitdev/zero-notification-service-client" \
           -p npmVersion="${{ github.event.release.tag_name }}" \
+          -p platform=node \
           -p moduleName="NotificationService"
         sudo chmod -R a+rw ${GITHUB_WORKSPACE}
 


### PR DESCRIPTION
so looks like the browser version didnt work for local, so if we want to use this straight from browser we may have to publish another client